### PR TITLE
Fixing ogmo3/tetra sample to work with tetra 0.6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 Cargo.lock
 SDL2.dll
+SDL2.lib

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ hashbrown = { version = "0.9", features = ["serde"] }
 either = "1.6.1"
 
 [dev-dependencies]
-tetra = "0.5"
+tetra = "0.6"
 anyhow = "1.0"
 pretty_assertions = "0.6.1"
 

--- a/examples/sample.rs
+++ b/examples/sample.rs
@@ -193,15 +193,9 @@ impl State<anyhow::Error> for GameState {
                     position,
                 } => {
                     let tileset = &self.tilesets[*tileset];
-                    let rect = tileset.tiles[*tile];
+                    let uv = tileset.tiles[*tile];
 
-                    tileset.texture.draw_region(
-                        ctx,
-                        rect,
-                        DrawParams::new()
-                            .position(*position)
-                            .scale(Vec2::new(1.0, 1.0)),
-                    );
+                    tileset.texture.draw_region(ctx, uv, *position);
                 }
 
                 Sprite::TileUV {
@@ -211,13 +205,7 @@ impl State<anyhow::Error> for GameState {
                 } => {
                     let tileset = &self.tilesets[*tileset];
 
-                    tileset.texture.draw_region(
-                        ctx,
-                        *uv,
-                        DrawParams::new()
-                            .position(*position)
-                            .scale(Vec2::new(1.0, 1.0)),
-                    );
+                    tileset.texture.draw_region(ctx, *uv, *position);
                 }
 
                 Sprite::Rect { rect, color } => {
@@ -241,11 +229,10 @@ impl State<anyhow::Error> for GameState {
                     texture.draw(
                         ctx,
                         DrawParams::new()
-                            // I had to hardcode values for origin until it looked right
-                            // I'm not sure where the values are suppoed to come from...my b
-                            // Pretty sure there was a bug in the tetra v0.5 version where
-                            // the decals weren't drawing in the correct location due to this.
-                            .origin(Vec2::new(32.0, 8.0))
+                            .origin(Vec2::new(
+                                texture.width() as f32 / 2.0,
+                                texture.height() as f32 / 2.0,
+                            ))
                             .position(*position)
                             .rotation(*rotation)
                             .scale(*scale),

--- a/examples/sample.rs
+++ b/examples/sample.rs
@@ -193,13 +193,14 @@ impl State<anyhow::Error> for GameState {
                     position,
                 } => {
                     let tileset = &self.tilesets[*tileset];
+                    let rect = tileset.tiles[*tile];
 
-                    graphics::draw(
+                    tileset.texture.draw_region(
                         ctx,
-                        &tileset.texture,
+                        rect,
                         DrawParams::new()
                             .position(*position)
-                            .clip(tileset.tiles[*tile]),
+                            .scale(Vec2::new(1.0, 1.0)),
                     );
                 }
 
@@ -210,17 +211,18 @@ impl State<anyhow::Error> for GameState {
                 } => {
                     let tileset = &self.tilesets[*tileset];
 
-                    graphics::draw(
+                    tileset.texture.draw_region(
                         ctx,
-                        &tileset.texture,
-                        DrawParams::new().position(*position).clip(*uv),
+                        *uv,
+                        DrawParams::new()
+                            .position(*position)
+                            .scale(Vec2::new(1.0, 1.0)),
                     );
                 }
 
                 Sprite::Rect { rect, color } => {
-                    graphics::draw(
+                    self.color_texture.draw(
                         ctx,
-                        &self.color_texture,
                         DrawParams::new()
                             .position(Vec2::new(rect.x, rect.y))
                             .scale(Vec2::new(rect.width, rect.height))
@@ -236,10 +238,14 @@ impl State<anyhow::Error> for GameState {
                 } => {
                     let texture = &self.decals[*decal];
 
-                    graphics::draw(
+                    texture.draw(
                         ctx,
-                        texture,
                         DrawParams::new()
+                            // I had to hardcode values for origin until it looked right
+                            // I'm not sure where the values are suppoed to come from...my b
+                            // Pretty sure there was a bug in the tetra v0.5 version where
+                            // the decals weren't drawing in the correct location due to this.
+                            .origin(Vec2::new(32.0, 8.0))
                             .position(*position)
                             .rotation(*rotation)
                             .scale(*scale),


### PR DESCRIPTION
Quick fix to make the tetra example use tetra 0.6. Hopefully will save people a few minutes debugging next time someone comes across it. I think it mostly boils down to a change in tetra 0.5 -> 0.6 where graphics::draw was removed (or so it seems, I could just be an idiot).

Speaking of being an idiot, there's still one very tiny issue with the drawing code that I believe was a bug with the last version as well. There's also a chance I'm just not understanding something about ogmo and decals and that the shift was intended. Check out these screenshots. You can see the decals shifted in the actual tetra rendering example.

![ogmo-good](https://user-images.githubusercontent.com/6384618/127866438-27837d6f-796a-4fcf-b3e3-f6b25a07917c.PNG)
![ogmo-bad](https://user-images.githubusercontent.com/6384618/127866445-ea16e89a-df50-4236-8ee6-6ce82b042512.PNG)

I left a comment in about this. I fiddled with some origin values until the decals looked like they were drawing in the right position. Obviously that's probably not what we want, and it should probably be changed by someone who understands where those values should come from.

One final caveat: I added SDL2.lib to the .gitignore. Probably not necessary, idk. I have my SDL2.lib in my project root so I had to copy it over to be able to run the samples.